### PR TITLE
fix: added message to print statements

### DIFF
--- a/storefront.py
+++ b/storefront.py
@@ -50,8 +50,8 @@ def main():
     """
 
     if len(sys.argv) != 2:
-        print()
-        print()
+        print("\nUsage: python3 storefront.py inventory.json")
+        print("Or you can make storefront.py an exicutable and run ./storefront.py inventory.json\n")
         sys.exit(1)
     
     inventory_file = sys.argv[1]


### PR DESCRIPTION
Needed to add the message to print() to tell user how to fix their command if missing the inventory file.